### PR TITLE
style: use HA secondary text color for media counter badge, reduce size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Media counter badge now uses HA secondary text color (`--secondary-text-color`) instead of fixed orange, and is slightly smaller
+
 ## [1.3.5]
 
 ### ⚠️ Check your dashboard resources after updating

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -87,10 +87,10 @@ export const styles = `
   }
 
   .count {
-    font-size: 0.75em;
-    padding: 4px 10px;
-    background: var(--arr-primary);
-    color: white;
+    font-size: 0.65em;
+    padding: 3px 8px;
+    background: var(--secondary-text-color);
+    color: var(--card-background-color, var(--ha-card-background, #1c1c1c));
     border-radius: 12px;
     font-weight: 600;
     white-space: nowrap;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -89,8 +89,9 @@ export const styles = `
   .count {
     font-size: 0.65em;
     padding: 3px 8px;
-    background: var(--secondary-text-color);
-    color: var(--card-background-color, var(--ha-card-background, #1c1c1c));
+    background: transparent;
+    color: var(--secondary-text-color);
+    border: 1px solid var(--secondary-text-color);
     border-radius: 12px;
     font-weight: 600;
     white-space: nowrap;


### PR DESCRIPTION
Replace fixed orange (#ff6600) background on the count badge with
--secondary-text-color so it adapts to the active HA theme. Also
reduced font-size from 0.75em to 0.65em and tightened padding slightly.

https://claude.ai/code/session_01PbSeFm262VtSGXNW6CM9SZ